### PR TITLE
Translations update from Guimauve Software's Weblate

### DIFF
--- a/android/src/main/res/values-fr/strings.xml
+++ b/android/src/main/res/values-fr/strings.xml
@@ -77,4 +77,5 @@
     <string name="clubs_button_join">Rejoindre le club</string>
     <string name="clubs_information_members">Membres</string>
     <string name="users_subscriptions_valid_until">Valable jusqu\'au %s</string>
+    <string name="settings_delete_account">Supprimer mon compte</string>
 </resources>

--- a/ios/SuiteBDE/fr.lproj/Localizable.strings
+++ b/ios/SuiteBDE/fr.lproj/Localizable.strings
@@ -81,3 +81,4 @@
 "notification_subscription_created_description" = "%@ t'a donné %@";
 "notification_subscription_updated_title" = "Cotisation mise à jour";
 "notification_subscription_updated_description" = "%@ a mis à jour %@";
+"settings_delete_account" = "Supprimer mon compte";


### PR DESCRIPTION
Translations update from [Guimauve Software's Weblate](https://weblate.guimauve.software) for [suitebde/ios](https://weblate.guimauve.software/projects/suitebde/ios/).


It also includes following components:

* [suitebde/android](https://weblate.guimauve.software/projects/suitebde/android/)



Current translation status:

![Weblate translation status](https://weblate.guimauve.software/widget/suitebde/ios/horizontal-auto.svg)